### PR TITLE
Added setQualifiers to RowScanner interface.  This was added in aysnchbase.

### DIFF
--- a/dropwizard-extra-hbase/src/main/java/com/datasift/dropwizard/hbase/scanner/BoundedRowScanner.java
+++ b/dropwizard-extra-hbase/src/main/java/com/datasift/dropwizard/hbase/scanner/BoundedRowScanner.java
@@ -144,6 +144,20 @@ public class BoundedRowScanner implements RowScanner {
     }
 
     /**
+     * Set the qualifier to select from cells
+     *
+     * @param qualifier the family to select from cells.
+     *
+     * @return this {@link RowScanner} to facilitate method chaining.
+     *
+     * @see org.hbase.async.Scanner#setQualifiers(byte[][])
+     */
+    public RowScanner setQualifiers(final byte[][] qualifiers) {
+        scanner.setQualifiers(qualifiers);
+        return this;
+    }
+
+    /**
      * Set a regular expression to filter keys being scanned.
      *
      * @param regexp a regular expression to filter keys with

--- a/dropwizard-extra-hbase/src/main/java/com/datasift/dropwizard/hbase/scanner/InstrumentedRowScanner.java
+++ b/dropwizard-extra-hbase/src/main/java/com/datasift/dropwizard/hbase/scanner/InstrumentedRowScanner.java
@@ -135,6 +135,20 @@ public class InstrumentedRowScanner implements RowScanner {
     /**
      * Set the qualifier to select from cells
      *
+     * @param qualifier the family to select from cells.
+     *
+     * @return this {@link RowScanner} to facilitate method chaining.
+     *
+     * @see org.hbase.async.Scanner#setQualifiers(byte[][])
+     */
+    public RowScanner setQualifiers(final byte[][] qualifiers) {
+        scanner.setQualifiers(qualifiers);
+        return this;
+    }
+
+    /**
+     * Set the qualifier to select from cells
+     *
      * @param qualifier the family to select from cells
      *
      * @return this {@link RowScanner} to facilitate method chaining

--- a/dropwizard-extra-hbase/src/main/java/com/datasift/dropwizard/hbase/scanner/RowScanner.java
+++ b/dropwizard-extra-hbase/src/main/java/com/datasift/dropwizard/hbase/scanner/RowScanner.java
@@ -95,6 +95,18 @@ public interface RowScanner {
     public RowScanner setQualifier(byte[] qualifier);
 
     /**
+     * Set the qualifiers to select from cells
+     *
+     * @param qualifiers the family to select from cells.
+     *
+     * @return this {@link RowScanner} to facilitate method chaining.
+     *
+     * @see org.hbase.async.Scanner#setQualifiers(byte[][])
+     */
+    public RowScanner setQualifiers(byte[][] qualifiers);
+
+
+    /**
      * Set the qualifier to select from cells
      *
      * @param qualifier the family to select from cells.

--- a/dropwizard-extra-hbase/src/main/java/com/datasift/dropwizard/hbase/scanner/RowScannerProxy.java
+++ b/dropwizard-extra-hbase/src/main/java/com/datasift/dropwizard/hbase/scanner/RowScannerProxy.java
@@ -133,6 +133,20 @@ public class RowScannerProxy implements RowScanner {
      *
      * @return this {@link RowScanner} to facilitate method chaining.
      *
+     * @see org.hbase.async.Scanner#setQualifiers(byte[][])
+     */
+    public RowScanner setQualifiers(final byte[][] qualifiers) {
+        scanner.setQualifiers(qualifiers);
+        return this;
+    }
+
+    /**
+     * Set the qualifier to select from cells
+     *
+     * @param qualifier the family to select from cells.
+     *
+     * @return this {@link RowScanner} to facilitate method chaining.
+     *
      * @see org.hbase.async.Scanner#setQualifier(String)
      */
     public RowScanner setQualifier(final String qualifier) {


### PR DESCRIPTION
In asynchbase 1.4, several methods were added to the Scanner.  I need access to setQualifiers() so added it to RowScanner and all the derivatives.
