### PR TITLE
fixes currator healthcheck

### DIFF
--- a/dropwizard-extra-curator/src/main/java/com/datasift/dropwizard/curator/health/CuratorHealthCheck.java
+++ b/dropwizard-extra-curator/src/main/java/com/datasift/dropwizard/curator/health/CuratorHealthCheck.java
@@ -30,9 +30,10 @@ public class CuratorHealthCheck extends HealthCheck {
      */
     @Override
     protected Result check() throws Exception {
+        String namespace = framework.getNamespace();
         if (!framework.isStarted()) {
             return Result.unhealthy("Client not started");
-        } else if (framework.checkExists().forPath("/") == null) {
+        } else if (framework.checkExists().forPath("".equals(namespace) ? "/" : "") == null) {
             return Result.unhealthy("Root for namespace does not exist");
         }
 


### PR DESCRIPTION
Previous check would always fail when a namespace was provided:

! zookeeper-curator-localhost:2181-data-state: ERROR
!  Path must not end with / character

java.lang.IllegalArgumentException: Path must not end with / character
    at org.apache.zookeeper.common.PathUtils.validatePath(PathUtils.java:58)
    at org.apache.zookeeper.ZooKeeper.exists(ZooKeeper.java:1020)
    at com.netflix.curator.framework.imps.ExistsBuilderImpl$2.call(ExistsBuilderImpl.java:171)
    at com.netflix.curator.framework.imps.ExistsBuilderImpl$2.call(ExistsBuilderImpl.java:160)
    at com.netflix.curator.RetryLoop.callWithRetry(RetryLoop.java:106)
    at com.netflix.curator.framework.imps.ExistsBuilderImpl.pathInForeground(ExistsBuilderImpl.java:156)
    at com.netflix.curator.framework.imps.ExistsBuilderImpl.forPath(ExistsBuilderImpl.java:147)
    at com.netflix.curator.framework.imps.ExistsBuilderImpl.forPath(ExistsBuilderImpl.java:35)
    at com.datasift.dropwizard.curator.health.CuratorHealthCheck.check(CuratorHealthCheck.java:39)
    at com.yammer.metrics.core.HealthCheck.execute(HealthCheck.java:195)
