### PR TITLE
Renaming Producer package to producer and making InstrumentedProducer implement Managed.

### DIFF
--- a/dropwizard-extra-kafka/src/main/java/com/datasift/dropwizard/kafka/KafkaProducerFactory.java
+++ b/dropwizard-extra-kafka/src/main/java/com/datasift/dropwizard/kafka/KafkaProducerFactory.java
@@ -1,7 +1,7 @@
 package com.datasift.dropwizard.kafka;
 
-import com.datasift.dropwizard.kafka.Producer.InstrumentedProducer;
-import com.datasift.dropwizard.kafka.Producer.KafkaProducer;
+import com.datasift.dropwizard.kafka.producer.InstrumentedProducer;
+import com.datasift.dropwizard.kafka.producer.KafkaProducer;
 import com.datasift.dropwizard.kafka.util.Compression;
 import com.datasift.dropwizard.zookeeper.ZooKeeperFactory;
 import com.google.common.base.Joiner;

--- a/dropwizard-extra-kafka/src/main/java/com/datasift/dropwizard/kafka/producer/InstrumentedProducer.java
+++ b/dropwizard-extra-kafka/src/main/java/com/datasift/dropwizard/kafka/producer/InstrumentedProducer.java
@@ -1,7 +1,8 @@
-package com.datasift.dropwizard.kafka.Producer;
+package com.datasift.dropwizard.kafka.producer;
 
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
+import io.dropwizard.lifecycle.Managed;
 import kafka.javaapi.producer.Producer;
 import kafka.producer.KeyedMessage;
 
@@ -10,7 +11,7 @@ import java.util.List;
 /**
  * A {@link Producer} that is instrumented with metrics.
  */
-public class InstrumentedProducer<K, V> implements KafkaProducer<K, V> {
+public class InstrumentedProducer<K, V> implements KafkaProducer<K, V>, Managed {
 
     private final Producer<K, V> underlying;
     private final Meter sentMessages;
@@ -34,5 +35,13 @@ public class InstrumentedProducer<K, V> implements KafkaProducer<K, V> {
 
     public void close() {
         underlying.close();
+    }
+
+    public void start() {
+        /* Nothing to do do here. */
+    }
+  
+    public void stop() {
+        close();
     }
 }

--- a/dropwizard-extra-kafka/src/main/java/com/datasift/dropwizard/kafka/producer/KafkaProducer.java
+++ b/dropwizard-extra-kafka/src/main/java/com/datasift/dropwizard/kafka/producer/KafkaProducer.java
@@ -1,4 +1,4 @@
-package com.datasift.dropwizard.kafka.Producer;
+package com.datasift.dropwizard.kafka.producer;
 
 import kafka.javaapi.producer.Producer;
 import kafka.producer.KeyedMessage;


### PR DESCRIPTION
1. Minor changes to make naming consistent with the `consumer` package.
2. `InstrumentedProducer` implements Managed.
