### PR TITLE
Make KafkaProducer managed by the dropwizard environment's lifecycle

### DIFF
--- a/dropwizard-extra-kafka/src/main/java/com/datasift/dropwizard/kafka/KafkaProducerFactory.java
+++ b/dropwizard-extra-kafka/src/main/java/com/datasift/dropwizard/kafka/KafkaProducerFactory.java
@@ -1,7 +1,7 @@
 package com.datasift.dropwizard.kafka;
 
-import com.datasift.dropwizard.kafka.Producer.InstrumentedProducer;
-import com.datasift.dropwizard.kafka.Producer.KafkaProducer;
+import com.datasift.dropwizard.kafka.producer.InstrumentedProducer;
+import com.datasift.dropwizard.kafka.producer.KafkaProducer;
 import com.datasift.dropwizard.kafka.util.Compression;
 import com.google.common.base.Joiner;
 import com.google.common.base.Optional;

--- a/dropwizard-extra-kafka/src/main/java/com/datasift/dropwizard/kafka/KafkaProducerFactory.java
+++ b/dropwizard-extra-kafka/src/main/java/com/datasift/dropwizard/kafka/KafkaProducerFactory.java
@@ -265,10 +265,14 @@ public class KafkaProducerFactory extends KafkaClientFactory {
                                        final Class<Partitioner> partitioner,
                                        final Environment environment,
                                        final String name) {
-        return new InstrumentedProducer<>(
+        InstrumentedProducer<K, V> instrumentedProducer = new InstrumentedProducer<>(
                 build(keyEncoder, messageEncoder, partitioner, name),
                 environment.metrics(),
                 name);
+
+        environment.lifecycle().manage(instrumentedProducer);
+
+        return instrumentedProducer;
     }
 
     public <K, V> Producer<K, V> build(final Class<? extends Encoder<K>> keyEncoder,

--- a/dropwizard-extra-kafka/src/main/java/com/datasift/dropwizard/kafka/producer/InstrumentedProducer.java
+++ b/dropwizard-extra-kafka/src/main/java/com/datasift/dropwizard/kafka/producer/InstrumentedProducer.java
@@ -4,11 +4,13 @@ import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
 import kafka.javaapi.producer.Producer;
 import kafka.producer.KeyedMessage;
+import io.dropwizard.lifecycle.Managed;
 
 import java.util.List;
 
 /**
- * A {@link Producer} that is instrumented with metrics.
+ * A {@link Producer} that is instrumented with metrics and support for being
+ * Managed by dropwizard lifecycle.
  */
 public class InstrumentedProducer<K, V> implements KafkaProducer<K, V> {
 
@@ -32,7 +34,7 @@ public class InstrumentedProducer<K, V> implements KafkaProducer<K, V> {
         sentMessages.mark(messages.size());
     }
 
-    public void close() {
-        underlying.close();
-    }
+    public void start() {}
+    public void stop() { underlying.close(); }
+    public void close() { underlying.close(); }
 }

--- a/dropwizard-extra-kafka/src/main/java/com/datasift/dropwizard/kafka/producer/InstrumentedProducer.java
+++ b/dropwizard-extra-kafka/src/main/java/com/datasift/dropwizard/kafka/producer/InstrumentedProducer.java
@@ -1,4 +1,4 @@
-package com.datasift.dropwizard.kafka.Producer;
+package com.datasift.dropwizard.kafka.producer;
 
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;

--- a/dropwizard-extra-kafka/src/main/java/com/datasift/dropwizard/kafka/producer/KafkaProducer.java
+++ b/dropwizard-extra-kafka/src/main/java/com/datasift/dropwizard/kafka/producer/KafkaProducer.java
@@ -1,4 +1,4 @@
-package com.datasift.dropwizard.kafka.Producer;
+package com.datasift.dropwizard.kafka.producer;
 
 import kafka.javaapi.producer.Producer;
 import kafka.producer.KeyedMessage;

--- a/dropwizard-extra-kafka/src/main/java/com/datasift/dropwizard/kafka/producer/KafkaProducer.java
+++ b/dropwizard-extra-kafka/src/main/java/com/datasift/dropwizard/kafka/producer/KafkaProducer.java
@@ -1,18 +1,19 @@
 package com.datasift.dropwizard.kafka.producer;
 
+import io.dropwizard.lifecycle.Managed;
 import kafka.javaapi.producer.Producer;
 import kafka.producer.KeyedMessage;
 
+import java.io.Closeable;
 import java.util.List;
 
 /**
  * Interface for {@link Producer} proxies.
  */
-public interface KafkaProducer<K, V> {
+public interface KafkaProducer<K, V> extends Managed, Closeable {
 
     public void send(KeyedMessage<K, V> message);
 
     public void send(List<KeyedMessage<K, V>> messages);
 
-    public void close();
 }


### PR DESCRIPTION
Note I added code to KafkaProducerFactory to register the producer on `environment.lifecycle()`, just like the consumer factory registers the consumer. This isn't a responsibility I'd normally expect a factory build method to have, but thought it best to stick to the project conventions.

While I was at it I made KafkaProducer's close method into an implementation of Closeable, which doesn't hurt and means it could be used with try-with-resources etc.

Also fixed what appeared to be a typo in the package name for producer.
