### PR TITLE
updated link for dropwizard-extra-scala which seem to have moved

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,9 @@ modules:
   working with [HBase](http://hbase.apache.org)
   * [dropwizard-extra-kafka](http://github.com/datasift/dropwizard-extra/tree/develop/dropwizard-extra-kafka) for 
   working with [Apache Kafka](http://incubator.apache.org/kafka).
-  * [dropwizard-extra-scala](http://github.com/datasift/dropwizard-extra/tree/develop/dropwizard-extra-scala) provides 
-  Scala integrations for Dropwizard and a more idiomatic Scala API to the other Dropwizard Extra modules.
+  * [dropwizard-extra-scala](https://github.com/datasift/dropwizard-scala) provides 
+  Scala integrations for Dropwizard and a more idiomatic Scala API to the other Dropwizard Extra modules. This project 
+  has moved to [dropwizard-scala](https://github.com/datasift/dropwizard-scala)
   * [dropwizard-extra-zookeeper](http://github.com/datasift/dropwizard-extra/tree/develop/dropwizard-extra-zookeeper)
   integrates the low-level [Apache ZooKeeper](http://zookeeper.apache.org/) client in to Dropwizards life-cycle. If 
   you're using ZooKeeper directly in your application, it's strongly recommended that you use the higher-level 


### PR DESCRIPTION
I noticed the link for dropwizard-extra-scala was broken. After a quick look around I noticed datasift has a new project called dropwizard-scala. I assumed this link should point to the new location and so created this pull request.
