### PR TITLE
Fix FD leak in SocketHealthCheck.

### DIFF
--- a/dropwizard-extra-util/src/main/java/com/datasift/dropwizard/health/SocketHealthCheck.java
+++ b/dropwizard-extra-util/src/main/java/com/datasift/dropwizard/health/SocketHealthCheck.java
@@ -67,11 +67,12 @@ public abstract class SocketHealthCheck extends HealthCheck {
      */
     @Override
     protected Result check() throws Exception {
-        final Socket socket = createSocket(hostname, port);
-        return socket.isConnected()
-                ? check(socket)
-                : Result.unhealthy(String.format(
-                        "Failed to connect to %s:%d", hostname, port));
+        try (final Socket socket = createSocket(hostname, port)) {
+            return socket.isConnected()
+                   ? check(socket)
+                   : Result.unhealthy(String.format(
+                           "Failed to connect to %s:%d", hostname, port));
+        }
     }
 
     /**


### PR DESCRIPTION
`SocketHealthCheck` doesn't explicitly close the socket it creates, hence FD leaks are likely possible.
