### PR TITLE
Allow DefaultPartitioner as the parameter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+language: java

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 Dropwizard Extra
 ================
+[![Build
+Status](https://travis-ci.org/ramv/dropwizard-extra.svg?branch=develop)](https://travis-ci.org/ramv/dropwizard-extra)
 
 *For those not content with the already excellent [Dropwizard](http://github.com/codahale/dropwizard)*
 

--- a/dropwizard-extra-kafka/src/main/java/com/datasift/dropwizard/kafka/KafkaProducerFactory.java
+++ b/dropwizard-extra-kafka/src/main/java/com/datasift/dropwizard/kafka/KafkaProducerFactory.java
@@ -265,7 +265,7 @@ public class KafkaProducerFactory extends KafkaClientFactory {
 
     public <K, V> KafkaProducer<K, V> build(final Class<? extends Encoder<K>> keyEncoder,
                                        final Class<? extends Encoder<V>> messageEncoder,
-                                       final Class<Partitioner> partitioner,
+                                       final Class<? extends Partitioner> partitioner,
                                        final Environment environment,
                                        final String name) {
         final Producer<K, V> producer = build(keyEncoder, messageEncoder, partitioner, name);
@@ -278,7 +278,7 @@ public class KafkaProducerFactory extends KafkaClientFactory {
 
     public <K, V> Producer<K, V> build(final Class<? extends Encoder<K>> keyEncoder,
                                        final Class<? extends Encoder<V>> messageEncoder,
-                                       final Class<Partitioner> partitioner,
+                                       final Class<? extends Partitioner> partitioner,
                                        final String name) {
         return new Producer<>(
                 toProducerConfig(this, messageEncoder, keyEncoder, partitioner, name));
@@ -287,7 +287,7 @@ public class KafkaProducerFactory extends KafkaClientFactory {
     static <K, V> ProducerConfig toProducerConfig(final KafkaProducerFactory factory,
                                                   final Class<? extends Encoder<V>> messageEncoder,
                                                   final Class<? extends Encoder<K>> keyEncoder,
-                                                  final Class<Partitioner> partitioner,
+                                                  final Class<? extends Partitioner> partitioner,
                                                   final String name) {
         final Properties properties = new Properties();
 

--- a/dropwizard-extra-kafka/src/test/java/com/datasift/dropwizard/kafka/KafkaProducerFactoryTest.java
+++ b/dropwizard-extra-kafka/src/test/java/com/datasift/dropwizard/kafka/KafkaProducerFactoryTest.java
@@ -6,6 +6,7 @@ import io.dropwizard.configuration.ConfigurationFactory;
 import io.dropwizard.jackson.Jackson;
 
 import kafka.producer.ProducerConfig;
+import kafka.producer.DefaultPartitioner;
 import kafka.serializer.DefaultEncoder;
 import org.junit.Before;
 import org.junit.Test;
@@ -41,4 +42,11 @@ public class KafkaProducerFactoryTest {
                 equalTo("localhost:4321,192.168.10.12:123,localhost:"
                         + DEFAULT_BROKER_PORT + ",192.168.4.21:" + DEFAULT_BROKER_PORT));
     }
+
+    @Test
+   public void testPartitioners(){
+      ProducerConfig config = KafkaProducerFactory.toProducerConfig(factory, DefaultEncoder.class, DefaultEncoder.class, DefaultPartitioner.class,  "test");
+      assertThat("partitioner class is correctly set", config.partitionerClass(), equalTo("kafka.producer.DefaultPartitioner"));
+   }
+
 }

--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,6 @@
     <module>dropwizard-extra-curator</module>
     <module>dropwizard-extra-hbase</module>
     <module>dropwizard-extra-kafka</module>
-    <module>dropwizard-extra-kafka7</module>
     <module>dropwizard-extra-zookeeper</module>
     <module>dropwizard-extra-util</module>
   </modules>


### PR DESCRIPTION
This enables subclasses of `Partitioner` class to be specified as argument to the `build` methods
