### PR TITLE
Update of Dropwizard Extra for newer Kafka, dropwizard, and asynchbase

### DIFF
--- a/dropwizard-extra-curator/pom.xml
+++ b/dropwizard-extra-curator/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.datasift.dropwizard</groupId>
     <artifactId>dropwizard-extra</artifactId>
-    <version>0.7.1-2-SNAPSHOT</version>
+    <version>0.9.1-1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   

--- a/dropwizard-extra-curator/src/main/java/com/datasift/dropwizard/curator/CuratorFactory.java
+++ b/dropwizard-extra-curator/src/main/java/com/datasift/dropwizard/curator/CuratorFactory.java
@@ -21,7 +21,7 @@ import javax.validation.constraints.NotNull;
 
 /**
  * A factory for creating and managing {@link CuratorFramework} instances.
- * <p/>
+ * <p>
  * The resulting {@link CuratorFramework} will have its lifecycle managed by the {@link Environment}
  * and will have {@link com.codahale.metrics.health.HealthCheck}s installed for the underlying ZooKeeper
  * ensemble.
@@ -118,7 +118,7 @@ public class CuratorFactory {
 
     /**
      * Returns the initial time to wait before retrying a failed connection.
-     * <p/>
+     * <p>
      * Subsequent retries will wait an exponential amount of time more than this.
      *
      * @return the initial time to wait before trying to connect again.
@@ -130,7 +130,7 @@ public class CuratorFactory {
 
     /**
      * Sets the initial time to wait before retrying a failed connection.
-     * <p/>
+     * <p>
      * Subsequent retries will wait an exponential amount of time more than this.
      *
      * @param backOffBaseTime the initial time to wait before trying to connect again.
@@ -142,7 +142,7 @@ public class CuratorFactory {
 
     /**
      * Returns a {@link RetryPolicy} for handling failed connection attempts.
-     * <p/>
+     * <p>
      * Always configures an {@link ExponentialBackoffRetry} based on the {@link #getMaxRetries()
      * maximum retries} and {@link #getBackOffBaseTime() initial back-off} configured.
      *

--- a/dropwizard-extra-curator/src/main/java/com/datasift/dropwizard/curator/ensemble/DropwizardConfiguredZooKeeperFactory.java
+++ b/dropwizard-extra-curator/src/main/java/com/datasift/dropwizard/curator/ensemble/DropwizardConfiguredZooKeeperFactory.java
@@ -12,7 +12,7 @@ import java.util.regex.Pattern;
 
 /**
  * Provides integration for Dropwizard's ZooKeeper functionality with Curator.
- * <p/>
+ * <p>
  * This ensures that {@link ZooKeeper} instances created by Curator integrate properly with the
  * Dropwizard application life-cycle.
  */

--- a/dropwizard-extra-hbase/pom.xml
+++ b/dropwizard-extra-hbase/pom.xml
@@ -30,7 +30,7 @@
     <dependency>
       <groupId>org.hbase</groupId>
       <artifactId>asynchbase</artifactId>
-      <version>1.4.1</version>
+      <version>1.7.0</version>
     </dependency>
   </dependencies>
 

--- a/dropwizard-extra-hbase/pom.xml
+++ b/dropwizard-extra-hbase/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.datasift.dropwizard</groupId>
     <artifactId>dropwizard-extra</artifactId>
-    <version>0.7.1-2-SNAPSHOT</version>
+    <version>0.9.1-1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   

--- a/dropwizard-extra-hbase/src/main/java/com/datasift/dropwizard/hbase/BoundedHBaseClient.java
+++ b/dropwizard-extra-hbase/src/main/java/com/datasift/dropwizard/hbase/BoundedHBaseClient.java
@@ -14,17 +14,17 @@ import java.util.concurrent.Semaphore;
 
 /**
  * An {@link HBaseClient} that constrains the maximum number of concurrent asynchronous requests.
- * <p/>
+ * <p>
  * This client places an upper-bounds on the number of concurrent asynchronous requests awaiting
  * completion. When this limit is reached, subsequent requests will block until an existing request
  * completes.
- * <p/>
+ * <p>
  * This behaviour is particularly useful for throttling high-throughput applications where HBase is
  * the bottle-neck. Without backing-off, such an application may run out of memory. By constraining
  * the maximum number of requests to a sufficiently high limit, but low enough so that it can be
  * reached without running out of memory, such applications can organically throttle and back-off
  * their requests.
- * <p/>
+ * <p>
  * Book-keeping of in-flight requests is done using a {@link Semaphore} which is configured as
  * "non-fair" to reduce its impact on request throughput.
  */
@@ -55,7 +55,7 @@ public class BoundedHBaseClient implements HBaseClient {
     /**
      * Create a new instance with the given semaphore for the given underlying {@link HBaseClient}
      * implementation.
-     * <p/>
+     * <p>
      * <i>Note: this is only really useful for sharing a {@link Semaphore} between two {@link
      * BoundedHBaseClient} instances, which only really makes sense for instances configured for
      * the same cluster, but with different client-side settings. <b>Use with caution!!</b></i>

--- a/dropwizard-extra-hbase/src/main/java/com/datasift/dropwizard/hbase/HBaseClient.java
+++ b/dropwizard-extra-hbase/src/main/java/com/datasift/dropwizard/hbase/HBaseClient.java
@@ -11,9 +11,9 @@ import java.util.ArrayList;
 
 /**
  * Client for interacting with an HBase cluster.
- * <p/>
+ * <p>
  * To create an instance, use {@link HBaseClientFactory}.
- * <p/>
+ * <p>
  * All implementations are wrapper proxies around {@link org.hbase.async.HBaseClient} providing
  * additional functionality.
  *
@@ -172,6 +172,7 @@ public interface HBaseClient {
      * Ensures that a specific table exists.
      *
      * @param table the table to check.
+     * @param family the family to check.
      *
      * @return a {@link Deferred} indicating the completion of the assertion.
      *
@@ -186,6 +187,7 @@ public interface HBaseClient {
      * Ensures that a specific table exists.
      *
      * @param table the table to check.
+     * @param family the family to check.
      *
      * @return a {@link Deferred} indicating the completion of the assertion.
      *

--- a/dropwizard-extra-hbase/src/main/java/com/datasift/dropwizard/hbase/HBaseClientFactory.java
+++ b/dropwizard-extra-hbase/src/main/java/com/datasift/dropwizard/hbase/HBaseClientFactory.java
@@ -13,7 +13,7 @@ import javax.validation.constraints.NotNull;
 
 /**
  * A factory for creating and managing {@link HBaseClient} instances.
- * <p/>
+ * <p>
  * The resulting {@link HBaseClient} will have its lifecycle managed by an {@link Environment} and
  * will have {@link com.codahale.metrics.health.HealthCheck}s installed for the {@code .META.} and
  * {@code -ROOT-} tables.
@@ -90,7 +90,7 @@ public class HBaseClientFactory {
 
     /**
      * Returns the maximum size of the buffer for increment operations.
-     * <p/>
+     * <p>
      * Once this buffer is full, a flush is forced irrespective of the {@link #getFlushInterval()
      * flushInterval}.
      *
@@ -105,7 +105,7 @@ public class HBaseClientFactory {
 
     /**
      * Sets the maximum size of the buffer for increment operations.
-     * <p/>
+     * <p>
      * Once this buffer is full, a flush is forced irrespective of the {@link #getFlushInterval()
      * flushInterval}.
      *
@@ -120,10 +120,10 @@ public class HBaseClientFactory {
 
     /**
      * Returns maximum number of concurrent asynchronous requests for the client.
-     * <p/>
+     * <p>
      * Useful for throttling high-throughput applications when HBase is the bottle-neck to prevent
      * the client running out of memory.
-     * <p/>
+     * <p>
      * With this is zero ("0"), no limit will be placed on the number of concurrent asynchronous
      * requests.
      *
@@ -138,10 +138,10 @@ public class HBaseClientFactory {
 
     /**
      * Sets the maximum number of concurrent asynchronous requests for the client.
-     * <p/>
+     * <p>
      * Useful for throttling high-throughput applications when HBase is the bottle-neck to prevent
      * the client running out of memory.
-     * <p/>
+     * <p>
      * With this is zero ("0"), no limit will be placed on the number of concurrent asynchronous
      * requests.
      *
@@ -229,7 +229,8 @@ public class HBaseClientFactory {
         client.setIncrementBufferSize(getIncrementBufferSize());
 
         // add healthchecks for META and ROOT tables
-        environment.healthChecks().register(name + "-meta", new HBaseHealthCheck(client, ".META."));
+        //environment.healthChecks().register(name + "-meta", new HBaseHealthCheck(client, ".META."));
+        environment.healthChecks().register(name + "-meta", new HBaseHealthCheck(client, "hbase:meta"));
         environment.healthChecks().register(name + "-root", new HBaseHealthCheck(client, "-ROOT-"));
 
         // manage client
@@ -241,11 +242,11 @@ public class HBaseClientFactory {
 
     /**
      * Builds a new {@link HBaseClient} according to the given {@link HBaseClientFactory}.
-     * <p/>
+     * <p>
      * If instrumentation {@link #instrumented is enabled} in the
      * configuration, this will build an {@link InstrumentedHBaseClient} wrapping the given {@link
      * HBaseClient}.
-     * <p/>
+     * <p>
      * If instrumentation is not enabled, the given {@link HBaseClient} will be returned verbatim.
      *
      * @param client an underlying {@link HBaseClient} implementation.
@@ -263,10 +264,10 @@ public class HBaseClientFactory {
 
     /**
      * Builds a new {@link HBaseClient} according to the given {@link HBaseClientFactory}.
-     * <p/>
+     * <p>
      * If the {@link #maxConcurrentRequests} is non-zero in the
      * configuration, this will build a {@link BoundedHBaseClient} that wraps the given client.
-     * <p/>
+     * <p>
      * If {@link #maxConcurrentRequests} is zero, the given {@link
      * HBaseClient} will be returned verbatim.
      *

--- a/dropwizard-extra-hbase/src/main/java/com/datasift/dropwizard/hbase/HBaseClientFactory.java
+++ b/dropwizard-extra-hbase/src/main/java/com/datasift/dropwizard/hbase/HBaseClientFactory.java
@@ -15,8 +15,7 @@ import javax.validation.constraints.NotNull;
  * A factory for creating and managing {@link HBaseClient} instances.
  * <p>
  * The resulting {@link HBaseClient} will have its lifecycle managed by an {@link Environment} and
- * will have {@link com.codahale.metrics.health.HealthCheck}s installed for the {@code .META.} and
- * {@code -ROOT-} tables.
+ * will have {@link com.codahale.metrics.health.HealthCheck}s installed for the {@code hbase:meta}.
  *
  * @see HBaseClient
  */
@@ -228,10 +227,8 @@ public class HBaseClientFactory {
         client.setFlushInterval(getFlushInterval());
         client.setIncrementBufferSize(getIncrementBufferSize());
 
-        // add healthchecks for META and ROOT tables
-        //environment.healthChecks().register(name + "-meta", new HBaseHealthCheck(client, ".META."));
+        // add healthchecks for hbase:meta table
         environment.healthChecks().register(name + "-meta", new HBaseHealthCheck(client, "hbase:meta"));
-        environment.healthChecks().register(name + "-root", new HBaseHealthCheck(client, "-ROOT-"));
 
         // manage client
         environment.lifecycle().manage(new ManagedHBaseClient(

--- a/dropwizard-extra-hbase/src/main/java/com/datasift/dropwizard/hbase/InstrumentedHBaseClient.java
+++ b/dropwizard-extra-hbase/src/main/java/com/datasift/dropwizard/hbase/InstrumentedHBaseClient.java
@@ -16,9 +16,9 @@ import java.util.ArrayList;
 
 /**
  * An {@link HBaseClient} that is instrumented with {@link Metric}s.
- * <p/>
+ * <p>
  * For each asynchronous request method, a {@link Timer} tracks the time taken for the request.
- * <p/>
+ * <p>
  * This implementation proxies all requests through an underlying {@link HBaseClient}; it merely
  * layers instrumentation on top of the underlying {@link HBaseClient}.
  *
@@ -38,9 +38,9 @@ public class InstrumentedHBaseClient implements HBaseClient {
 
     /**
      * Creates a new {@link InstrumentedHBaseClient} for the given underlying client.
-     * <p/>
+     * <p>
      * Instrumentation will be registered with the given {@link MetricRegistry}.
-     * <p/>
+     * <p>
      * A new {@link HBaseInstrumentation} container will be created for this {@link HBaseClient}
      * with the given {@link MetricRegistry}.
      *

--- a/dropwizard-extra-hbase/src/main/java/com/datasift/dropwizard/hbase/ManagedHBaseClient.java
+++ b/dropwizard-extra-hbase/src/main/java/com/datasift/dropwizard/hbase/ManagedHBaseClient.java
@@ -29,11 +29,11 @@ public class ManagedHBaseClient implements Managed {
      * To force the connection, we look for the prescence of the .META. table.
      *
      * @throws com.stumbleupon.async.TimeoutException if there is a problem connecting to HBase.
-     * @throws org.hbase.async.TableNotFoundException if the .META. table can't be found.
-     * @throws Exception if there is a problem verifying the .META. table exists.
+     * @throws org.hbase.async.TableNotFoundException if the hbase:meta table can't be found.
+     * @throws Exception if there is a problem verifying the hbase:meta table exists.
      */
     public void start() throws Exception {
-        client.ensureTableExists(".META.").joinUninterruptibly(connectionTimeout.toMilliseconds());
+        client.ensureTableExists("hbase:meta").joinUninterruptibly(connectionTimeout.toMilliseconds());
     }
 
     /**

--- a/dropwizard-extra-hbase/src/main/java/com/datasift/dropwizard/hbase/metrics/HBaseInstrumentation.java
+++ b/dropwizard-extra-hbase/src/main/java/com/datasift/dropwizard/hbase/metrics/HBaseInstrumentation.java
@@ -30,7 +30,7 @@ public class HBaseInstrumentation {
 
     /**
      * Initialises instrumentation for the given {@link HBaseClient} using the given {@link
-     * MetricsRegistry}.
+     * com.codahale.metrics.MetricRegistry}.
      *
      * @param client   the client to create metrics for.
      * @param registry the registry to register the metrics with.

--- a/dropwizard-extra-hbase/src/main/java/com/datasift/dropwizard/hbase/scanner/BoundedRowScanner.java
+++ b/dropwizard-extra-hbase/src/main/java/com/datasift/dropwizard/hbase/scanner/BoundedRowScanner.java
@@ -11,7 +11,7 @@ import java.util.concurrent.Semaphore;
 
 /**
  * A Scanner that constraints concurrent requests with a {@link Semaphore}.
- * <p/>
+ * <p>
  * To obtain an instance of a {@link RowScanner}, call {@link BoundedHBaseClient#scan(byte[])}.
  */
 public class BoundedRowScanner implements RowScanner {

--- a/dropwizard-extra-hbase/src/main/java/com/datasift/dropwizard/hbase/scanner/InstrumentedRowScanner.java
+++ b/dropwizard-extra-hbase/src/main/java/com/datasift/dropwizard/hbase/scanner/InstrumentedRowScanner.java
@@ -14,7 +14,7 @@ import java.util.ArrayList;
 
 /**
  * A {@link RowScanner} that is instrumented with {@link Metric}s.
- * <p/>
+ * <p>
  * To obtain an instance of a {@link RowScanner}, call {@link InstrumentedHBaseClient#scan(byte[])}.
  */
 public class InstrumentedRowScanner implements RowScanner {

--- a/dropwizard-extra-hbase/src/main/java/com/datasift/dropwizard/hbase/scanner/RowScanner.java
+++ b/dropwizard-extra-hbase/src/main/java/com/datasift/dropwizard/hbase/scanner/RowScanner.java
@@ -8,10 +8,10 @@ import java.util.ArrayList;
 
 /**
  * Client for scanning over a selection of rows.
- * <p/>
+ * <p>
  * To obtain an instance of a {@link RowScanner}, call {@link
  * com.datasift.dropwizard.hbase.HBaseClient#scan(byte[])}.
- * <p/>
+ * <p>
  * All implementations are wrapper proxies around {@link org.hbase.async.Scanner} providing
  * additional functionality.
  */

--- a/dropwizard-extra-hbase/src/main/java/com/datasift/dropwizard/hbase/scanner/RowScannerProxy.java
+++ b/dropwizard-extra-hbase/src/main/java/com/datasift/dropwizard/hbase/scanner/RowScannerProxy.java
@@ -9,10 +9,10 @@ import java.util.ArrayList;
 
 /**
  * Client for scanning over a selection of rows.
- * <p/>
+ * <p>
  * To obtain an instance of a {@link RowScanner}, call {@link
  * com.datasift.dropwizard.hbase.HBaseClient#scan(byte[])}.
- * <p/>
+ * <p>
  * This implementation is a proxy for a {@link org.hbase.async.Scanner}.
  */
 public class RowScannerProxy implements RowScanner {

--- a/dropwizard-extra-hbase/src/main/java/com/datasift/dropwizard/hbase/util/TimerStoppingCallback.java
+++ b/dropwizard-extra-hbase/src/main/java/com/datasift/dropwizard/hbase/util/TimerStoppingCallback.java
@@ -4,19 +4,19 @@ import com.stumbleupon.async.Callback;
 import com.codahale.metrics.Timer;
 
 /**
- * A {@link Callback} for stopping a {@link TimerContext} on completion.
+ * A {@link com.stumbleupon.async.Callback} for stopping a {@link com.codahale.metrics.Timer.Context} on completion.
  */
 public class TimerStoppingCallback<T> implements Callback<T, T> {
 
     /**
-     * The context of the active {@link com.yammer.metrics.core.Timer} to stop.
+     * The context of the active {@link com.codahale.metrics.Timer} to stop.
      */
     private final Timer.Context timer;
 
     /**
      * Creates a new {@link Callback} that stops the given active timer on completion.
      *
-     * @param timer the active {@link com.yammer.metrics.core.Timer} to stop on completion of the
+     * @param timer the active {@link com.codahale.metrics.Timer} to stop on completion of the
      *              {@link Callback}.
      */
     public TimerStoppingCallback(final Timer.Context timer) {
@@ -24,14 +24,14 @@ public class TimerStoppingCallback<T> implements Callback<T, T> {
     }
 
     /**
-     * Stops the registered {@link com.yammer.metrics.core.Timer} and proxies any argument through
+     * Stops the registered {@link com.codahale.metrics.Timer} and proxies any argument through
      * verbatim.
      *
      * @param arg the argument (if any) to pass-through.
      *
      * @return the argument (if any), proxied verbatim.
      *
-     * @throws Exception if an error occurs stopping the {@link com.yammer.metrics.core.Timer}.
+     * @throws Exception if an error occurs stopping the {@link com.codahale.metrics.Timer}.
      */
     public T call(final T arg) throws Exception {
         timer.stop();

--- a/dropwizard-extra-hbase/src/test/java/com/datasift/dropwizard/hbase/InstrumentedHBaseClientTest.java
+++ b/dropwizard-extra-hbase/src/test/java/com/datasift/dropwizard/hbase/InstrumentedHBaseClientTest.java
@@ -20,7 +20,7 @@ import static org.junit.Assert.assertThat;
 
 /**
  * Tests {@link InstrumentedHBaseClient}.
- * <p/>
+ * <p>
  * Each method is tested first, that it proxies its implementation to the underlying {@link
  * HBaseClient}, and then that the method is timed as expected.
  */

--- a/dropwizard-extra-kafka/pom.xml
+++ b/dropwizard-extra-kafka/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.datasift.dropwizard</groupId>
     <artifactId>dropwizard-extra</artifactId>
-    <version>0.7.1-2-SNAPSHOT</version>
+    <version>0.9.1-1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/dropwizard-extra-kafka/pom.xml
+++ b/dropwizard-extra-kafka/pom.xml
@@ -18,10 +18,10 @@
   </description>
 
   <properties>
-    <kafka.version>0.8.1.1</kafka.version>
+    <kafka.version>0.8.2.2</kafka.version>
     <scala.version>2.10</scala.version>
   </properties>
-
+<!-- 
     <dependencyManagement>
         <dependencies>
             <dependency>
@@ -31,7 +31,7 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
-
+ -->
   <dependencies>
     <dependency>
       <groupId>io.dropwizard</groupId>

--- a/dropwizard-extra-kafka/src/main/java/com/datasift/dropwizard/kafka/KafkaConsumerFactory.java
+++ b/dropwizard-extra-kafka/src/main/java/com/datasift/dropwizard/kafka/KafkaConsumerFactory.java
@@ -28,10 +28,10 @@ import java.util.concurrent.ScheduledExecutorService;
 
 /**
  * A factory for creating and managing {@link KafkaConsumer} instances.
- * <p/>
+ * <p>
  * The {@link KafkaConsumer} implementation will be determined by the configuration used to create
  * it.
- * <p/>
+ * <p>
  * The resultant {@link KafkaConsumer} will have its lifecycle managed by the {@link Environment}
  * and will have {@link com.codahale.metrics.health.HealthCheck}s installed to monitor its status.
  */
@@ -42,7 +42,7 @@ public class KafkaConsumerFactory extends KafkaClientFactory {
     /**
      * A description of the initial offset to consume from a partition when no committed offset
      * exists.
-     * <p/>
+     * <p>
      * <dl>
      *     <dt>SMALLEST</dt><dd>Use the smallest (i.e. earliest) available offset. In effect,
      *                          consuming the entire log.</dd>
@@ -150,7 +150,7 @@ public class KafkaConsumerFactory extends KafkaClientFactory {
 
     /**
      * Returns a mapping of the number of partitions to consume from each topic.
-     * <p/>
+     * <p>
      * Topics not referenced will not be consumed from.
      *
      * @return a Map of topics to the number of partitions to consume from them.
@@ -162,7 +162,7 @@ public class KafkaConsumerFactory extends KafkaClientFactory {
 
     /**
      * Sets a mapping of the number of partitions to consume from each topic.
-     * <p/>
+     * <p>
      * Topics not referenced will not be consumed from.
      *
      * @param partitions a Map of topics to the number of partitions to consume from them.
@@ -175,7 +175,7 @@ public class KafkaConsumerFactory extends KafkaClientFactory {
     /**
      * Returns the time the {@link KafkaConsumer} should wait to receive messages before timing out
      * the stream.
-     * <p/>
+     * <p>
      * When a {@link KafkaConsumer} times out a stream, a {@link
      * kafka.consumer.ConsumerTimeoutException} will be thrown by that streams' {@link
      * kafka.consumer.ConsumerIterator}.
@@ -194,7 +194,7 @@ public class KafkaConsumerFactory extends KafkaClientFactory {
     /**
      * Sets the time the {@link KafkaConsumer} should wait to receive messages before timing out
      * the stream.
-     * <p/>
+     * <p>
      * When a {@link KafkaConsumer} times out a stream, a {@link
      * kafka.consumer.ConsumerTimeoutException} will be thrown by that streams' {@link
      * kafka.consumer.ConsumerIterator}.
@@ -230,7 +230,7 @@ public class KafkaConsumerFactory extends KafkaClientFactory {
 
     /**
      * Returns the maximum size of a batch of messages to fetch in a single request.
-     * <p/>
+     * <p>
      * This dictates the maximum size of a message that may be received by the {@link
      * KafkaConsumer}. Messages larger than this size will cause a {@link
      * kafka.common.InvalidMessageSizeException} to be thrown during iteration of the stream.
@@ -246,7 +246,7 @@ public class KafkaConsumerFactory extends KafkaClientFactory {
 
     /**
      * Sets the maximum size of a batch of messages to fetch in a single request.
-     * <p/>
+     * <p>
      * This dictates the maximum size of a message that may be received by the {@link
      * KafkaConsumer}. Messages larger than this size will cause a {@link
      * kafka.common.InvalidMessageSizeException} to be thrown during iteration of the stream.
@@ -262,7 +262,7 @@ public class KafkaConsumerFactory extends KafkaClientFactory {
 
     /**
      * Returns the cumulative delay before polling a broker again when no data is returned.
-     * <p/>
+     * <p>
      * When fetching data from a broker, if there is no new data, there will be a delay before
      * polling the broker again. This controls the duration of the delay by increasing it linearly,
      * on each poll attempt.
@@ -276,7 +276,7 @@ public class KafkaConsumerFactory extends KafkaClientFactory {
 
     /**
      * Sets the cumulative delay before polling a broker again when no data is returned.
-     * <p/>
+     * <p>
      * When fetching data from a broker, if there is no new data, there will be a delay before
      * polling the broker again. This controls the duration of the delay by increasing it linearly,
      * on each poll attempt.
@@ -290,12 +290,14 @@ public class KafkaConsumerFactory extends KafkaClientFactory {
 
     /**
      * Returns the maximum number of chunks to queue in internal buffers.
-     * <p/>
+     * <p>
      * The consumer internally buffers fetched messages in a set of queues, which are used to
      * iterate the stream. This controls the size of these queues.
-     * <p/>
+     * <p>
      * Once a queue has been filled, it will block subsequent attempts to fill it until (some of) it
      * has been iterated.
+     * 
+     * @return the maximum number of chunks to queue in internal buffers
      */
     @JsonProperty
     public int getQueuedChunks() {
@@ -304,12 +306,14 @@ public class KafkaConsumerFactory extends KafkaClientFactory {
 
     /**
      * Sets the maximum number of chunks to queue in internal buffers.
-     * <p/>
+     * <p>
      * The consumer internally buffers fetched messages in a set of queues, which are used to
      * iterate the stream. This controls the size of these queues.
-     * <p/>
+     * <p>
      * Once a queue has been filled, it will block subsequent attempts to fill it until (some of) it
      * has been iterated.
+     * 
+     * @param maxChunks the maximium number of chunks to queue
      */
     @JsonProperty
     public void setQueuedChunks(final int maxChunks) {
@@ -342,7 +346,7 @@ public class KafkaConsumerFactory extends KafkaClientFactory {
     }
 
     /**
-     * Sets the frequency to automatically commit previously consumed offsets, if enabled.
+     * Gets the frequency to automatically commit previously consumed offsets, if enabled.
      *
      * @return the frequency to automatically commit the previously consumed offsets, when enabled.
      *
@@ -355,9 +359,9 @@ public class KafkaConsumerFactory extends KafkaClientFactory {
 
 
     /**
-     * Returns the frequency to automatically commit previously consumed offsets, if enabled.
-     *
-     * @return the frequency to automatically commit the previously consumed offsets, when enabled.
+     * Sets the frequency to automatically commit previously consumed offsets, if enabled.
+     * 
+     * @param autoCommitInterval the frequency with which to auto commit.
      *
      * @see #getAutoCommit
      */
@@ -492,7 +496,7 @@ public class KafkaConsumerFactory extends KafkaClientFactory {
     /**
      * Prepares a {@link KafkaConsumerBuilder} for a given {@link Decoder} and {@link
      * StreamProcessor}.
-     * <p/>
+     * <p>
      * The decoder instance is used to decode {@link Message}s in the stream before being passed to
      * the processor.
      *
@@ -546,10 +550,10 @@ public class KafkaConsumerFactory extends KafkaClientFactory {
         /**
          * Builds a {@link KafkaConsumer} instance from the given {@link ExecutorService} and name,
          * for the given {@link Environment}.
-         * <p/>
+         * <p>
          * The name is used to identify the returned {@link KafkaConsumer} instance, for example, as
          * the name of its {@link com.codahale.metrics.health.HealthCheck}s, thread pool, etc.
-         * <p/>
+         * <p>
          * This implementation creates a new {@link ExecutorService} with a fixed-size thread-pool,
          * configured for one thread per-partition the {@link KafkaConsumer} is being configured to
          * consume.
@@ -578,7 +582,7 @@ public class KafkaConsumerFactory extends KafkaClientFactory {
         /**
          * Builds a {@link KafkaConsumer} instance from the given {@link ExecutorService} and name,
          * for the given {@link Environment}.
-         * <p/>
+         * <p>
          * The name is used to identify the returned {@link KafkaConsumer} instance, for example, as
          * the name of its {@link com.codahale.metrics.health.HealthCheck}s, etc.
          *
@@ -607,7 +611,7 @@ public class KafkaConsumerFactory extends KafkaClientFactory {
         /**
          * Builds a {@link SynchronousConsumer} instance with this builders' configuration using the
          * given {@link ExecutorService}.
-         * <p/>
+         * <p>
          * If possible, it's always preferable to use one of the overloads that take an {@link
          * Environment} directly. This overload exists for situations where you don't have access to
          * an {@link Environment} (e.g. some Commands or unit tests).

--- a/dropwizard-extra-kafka/src/main/java/com/datasift/dropwizard/kafka/KafkaProducerFactory.java
+++ b/dropwizard-extra-kafka/src/main/java/com/datasift/dropwizard/kafka/KafkaProducerFactory.java
@@ -26,10 +26,10 @@ import java.util.Properties;
 
 /**
  * Configuration for the Kafka producer.
- * <p/>
+ * <p>
  * By default, the producer will be synchronous, blocking the calling thread until the message has
  * been sent.
- * <p/>
+ * <p>
  * To use an asynchronous producer, set {@link KafkaProducerFactory#async} with the desired
  * properties.
  */
@@ -250,7 +250,7 @@ public class KafkaProducerFactory extends KafkaClientFactory {
     public void setClientIdSuffix(final Optional<String> clientIdSuffix) {
         this.clientIdSuffix = clientIdSuffix;
     }
-
+    
     public <V> KafkaProducer<?, V> build(final Class<? extends Encoder<V>> messageEncoder,
                                     final Environment environment,
                                     final String name) {

--- a/dropwizard-extra-kafka/src/main/java/com/datasift/dropwizard/kafka/consumer/MessageProcessor.java
+++ b/dropwizard-extra-kafka/src/main/java/com/datasift/dropwizard/kafka/consumer/MessageProcessor.java
@@ -6,7 +6,7 @@ import kafka.message.MessageAndMetadata;
 
 /**
  * Processes messages of type {@code T} from a Kafka message stream.
- * <p/>
+ * <p>
  * This {@link StreamProcessor} is instrumented with {@link Metric}s; specifically, a {@link Timer}
  * that tracks the time taken to process each message in the stream.
  *

--- a/dropwizard-extra-kafka/src/main/java/com/datasift/dropwizard/kafka/consumer/StreamProcessor.java
+++ b/dropwizard-extra-kafka/src/main/java/com/datasift/dropwizard/kafka/consumer/StreamProcessor.java
@@ -4,10 +4,10 @@ import kafka.message.MessageAndMetadata;
 
 /**
  * Processes an {@link Iterable} of messages of type {@code T}.
- * <p/>
+ * <p>
  * If you wish to process each message individually and iteratively, it's advised that you instead
  * use a {@link MessageProcessor}, as it provides a higher-level of abstraction.
- * <p/>
+ * <p>
  * <i>Note: since consumers may use multiple threads, it is important that implementations are
  * thread-safe.</i>
  */

--- a/dropwizard-extra-kafka/src/main/java/com/datasift/dropwizard/kafka/consumer/SynchronousConsumer.java
+++ b/dropwizard-extra-kafka/src/main/java/com/datasift/dropwizard/kafka/consumer/SynchronousConsumer.java
@@ -71,11 +71,17 @@ public class SynchronousConsumer<K, V> implements KafkaConsumer, Managed, Server
      * Creates a {@link SynchronousConsumer} to process a stream.
      *
      * @param connector the {@link ConsumerConnector} of the underlying consumer.
-     * @param partitions a mapping of the topic -> partitions to consume.
+     * @param partitions a mapping of the topic with the partitions to consume.
      * @param keyDecoder a {@link Decoder} for decoding the key of each message before being processed.
      * @param valueDecoder a {@link Decoder} for decoding each message before being processed.
      * @param processor a {@link StreamProcessor} for processing messages.
      * @param executor the {@link ExecutorService} to process the stream with.
+     * @param initialRecoveryDelay the initial recovery delay
+     * @param maxRecoveryDelay the max recovery delay
+     * @param retryResetDelay 
+     * @param maxRecoveryAttempts the number of time to attempt recovery
+     * @param shutdownOnFatal booelan stating whether or not to shut down on fatal error
+     * @param startDelay the amount of time to delay at start
      */
     public SynchronousConsumer(final ConsumerConnector connector,
                                final Map<String, Integer> partitions,
@@ -120,11 +126,11 @@ public class SynchronousConsumer<K, V> implements KafkaConsumer, Managed, Server
 
     /**
      * Starts this {@link SynchronousConsumer} immediately.
-     * <p/>
+     * <p>
      * The consumer will immediately begin consuming from the configured topics using the configured
      * {@link Decoder} to decode messages and {@link StreamProcessor} to process the decoded
      * messages.
-     * <p/>
+     * <p>
      * Each partition will be consumed using a separate thread.
      *
      * @throws Exception if an error occurs starting the consumer
@@ -152,7 +158,7 @@ public class SynchronousConsumer<K, V> implements KafkaConsumer, Managed, Server
     /**
      * Stops this {@link SynchronousConsumer} immediately.
      *
-     * @throws Exception
+     * @throws Exception if an error occurs on stop
      */
     @Override
     public void stop() throws Exception {
@@ -201,10 +207,10 @@ public class SynchronousConsumer<K, V> implements KafkaConsumer, Managed, Server
 
         /**
          * Process the stream using the configured {@link StreamProcessor}.
-         * <p/>
+         * <p>
          * If an {@link Exception} is thrown during processing, if it is deemed <i>recoverable</i>,
          * the stream will continue to be consumed.
-         * <p/>
+         * <p>
          * Unrecoverable {@link Exception}s will cause the consumer to shut down completely.
          */
         @Override

--- a/dropwizard-extra-kafka/src/main/java/com/datasift/dropwizard/kafka/util/Compression.java
+++ b/dropwizard-extra-kafka/src/main/java/com/datasift/dropwizard/kafka/util/Compression.java
@@ -9,10 +9,10 @@ import kafka.message.NoCompressionCodec;
 /**
  * A utility for parsing {@link CompressionCodec}s from a {@link
  * io.dropwizard.Configuration}.
- * <p/>
+ * <p>
  * To create {@link Compression} instances, use {@link Compression#parse(String)} to parse an
  * instance from a {@link String}.
- * <p/>
+ * <p>
  * This is provided to parse textual specifications of a {@link CompressionCodec}, for example in a
  * {@link io.dropwizard.Configuration}.
  */
@@ -22,9 +22,9 @@ public class Compression {
 
     /**
      * Creates a {@link Compression} instance for the given codec type.
-     * <p/>
+     * <p>
      * The valid codec values are defined by {@link CompressionCodec}.
-     * <p/>
+     * <p>
      * To create {@link Compression} instances, use the {@link Compression#parse(String)} factory
      * method to parse an instance from a {@link String}.
      *

--- a/dropwizard-extra-kafka7/pom.xml
+++ b/dropwizard-extra-kafka7/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.datasift.dropwizard</groupId>
         <artifactId>dropwizard-extra</artifactId>
-        <version>0.7.1-2-SNAPSHOT</version>
+        <version>0.9.1-1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/dropwizard-extra-kafka7/src/main/java/com/datasift/dropwizard/kafka/KafkaConsumerFactory.java
+++ b/dropwizard-extra-kafka7/src/main/java/com/datasift/dropwizard/kafka/KafkaConsumerFactory.java
@@ -27,10 +27,10 @@ import java.util.concurrent.ScheduledExecutorService;
 
 /**
  * A factory for creating and managing {@link KafkaConsumer} instances.
- * <p/>
+ * <p>
  * The {@link KafkaConsumer} implementation will be determined by the configuration used to create
  * it.
- * <p/>
+ * <p>
  * The resultant {@link KafkaConsumer} will have its lifecycle managed by the {@link Environment}
  * and will have {@link com.codahale.metrics.health.HealthCheck}s installed to monitor its status.
  */
@@ -41,7 +41,7 @@ public class KafkaConsumerFactory extends KafkaClientFactory {
     /**
      * A description of the initial offset to consume from a partition when no committed offset
      * exists.
-     * <p/>
+     * <p>
      * <dl>
      *     <dt>SMALLEST</dt><dd>Use the smallest (i.e. earliest) available offset. In effect,
      *                          consuming the entire log.</dd>
@@ -149,7 +149,7 @@ public class KafkaConsumerFactory extends KafkaClientFactory {
 
     /**
      * Returns a mapping of the number of partitions to consume from each topic.
-     * <p/>
+     * <p>
      * Topics not referenced will not be consumed from.
      *
      * @return a Map of topics to the number of partitions to consume from them.
@@ -161,7 +161,7 @@ public class KafkaConsumerFactory extends KafkaClientFactory {
 
     /**
      * Sets a mapping of the number of partitions to consume from each topic.
-     * <p/>
+     * <p>
      * Topics not referenced will not be consumed from.
      *
      * @param partitions a Map of topics to the number of partitions to consume from them.
@@ -174,7 +174,7 @@ public class KafkaConsumerFactory extends KafkaClientFactory {
     /**
      * Returns the time the {@link KafkaConsumer} should wait to receive messages before timing out
      * the stream.
-     * <p/>
+     * <p>
      * When a {@link KafkaConsumer} times out a stream, a {@link
      * kafka.consumer.ConsumerTimeoutException} will be thrown by that streams' {@link
      * kafka.consumer.ConsumerIterator}.
@@ -193,7 +193,7 @@ public class KafkaConsumerFactory extends KafkaClientFactory {
     /**
      * Sets the time the {@link KafkaConsumer} should wait to receive messages before timing out
      * the stream.
-     * <p/>
+     * <p>
      * When a {@link KafkaConsumer} times out a stream, a {@link
      * kafka.consumer.ConsumerTimeoutException} will be thrown by that streams' {@link
      * kafka.consumer.ConsumerIterator}.
@@ -229,7 +229,7 @@ public class KafkaConsumerFactory extends KafkaClientFactory {
 
     /**
      * Returns the maximum size of a batch of messages to fetch in a single request.
-     * <p/>
+     * <p>
      * This dictates the maximum size of a message that may be received by the {@link
      * KafkaConsumer}. Messages larger than this size will cause a {@link
      * kafka.common.InvalidMessageSizeException} to be thrown during iteration of the stream.
@@ -245,7 +245,7 @@ public class KafkaConsumerFactory extends KafkaClientFactory {
 
     /**
      * Sets the maximum size of a batch of messages to fetch in a single request.
-     * <p/>
+     * <p>
      * This dictates the maximum size of a message that may be received by the {@link
      * KafkaConsumer}. Messages larger than this size will cause a {@link
      * kafka.common.InvalidMessageSizeException} to be thrown during iteration of the stream.
@@ -261,7 +261,7 @@ public class KafkaConsumerFactory extends KafkaClientFactory {
 
     /**
      * Returns the cumulative delay before polling a broker again when no data is returned.
-     * <p/>
+     * <p>
      * When fetching data from a broker, if there is no new data, there will be a delay before
      * polling the broker again. This controls the duration of the delay by increasing it linearly,
      * on each poll attempt.
@@ -275,7 +275,7 @@ public class KafkaConsumerFactory extends KafkaClientFactory {
 
     /**
      * Sets the cumulative delay before polling a broker again when no data is returned.
-     * <p/>
+     * <p>
      * When fetching data from a broker, if there is no new data, there will be a delay before
      * polling the broker again. This controls the duration of the delay by increasing it linearly,
      * on each poll attempt.
@@ -289,10 +289,10 @@ public class KafkaConsumerFactory extends KafkaClientFactory {
 
     /**
      * Returns the maximum number of chunks to queue in internal buffers.
-     * <p/>
+     * <p>
      * The consumer internally buffers fetched messages in a set of queues, which are used to
      * iterate the stream. This controls the size of these queues.
-     * <p/>
+     * <p>
      * Once a queue has been filled, it will block subsequent attempts to fill it until (some of) it
      * has been iterated.
      */
@@ -303,10 +303,10 @@ public class KafkaConsumerFactory extends KafkaClientFactory {
 
     /**
      * Sets the maximum number of chunks to queue in internal buffers.
-     * <p/>
+     * <p>
      * The consumer internally buffers fetched messages in a set of queues, which are used to
      * iterate the stream. This controls the size of these queues.
-     * <p/>
+     * <p>
      * Once a queue has been filled, it will block subsequent attempts to fill it until (some of) it
      * has been iterated.
      */
@@ -491,7 +491,7 @@ public class KafkaConsumerFactory extends KafkaClientFactory {
     /**
      * Prepares a {@link KafkaConsumerBuilder} for a given {@link Decoder} and {@link
      * StreamProcessor}.
-     * <p/>
+     * <p>
      * The decoder instance is used to decode {@link Message}s in the stream before being passed to
      * the processor.
      *
@@ -536,10 +536,10 @@ public class KafkaConsumerFactory extends KafkaClientFactory {
         /**
          * Builds a {@link KafkaConsumer} instance from the given {@link ExecutorService} and name,
          * for the given {@link Environment}.
-         * <p/>
+         * <p>
          * The name is used to identify the returned {@link KafkaConsumer} instance, for example, as
          * the name of its {@link com.codahale.metrics.health.HealthCheck}s, thread pool, etc.
-         * <p/>
+         * <p>
          * This implementation creates a new {@link ExecutorService} with a fixed-size thread-pool,
          * configured for one thread per-partition the {@link KafkaConsumer} is being configured to
          * consume.
@@ -568,7 +568,7 @@ public class KafkaConsumerFactory extends KafkaClientFactory {
         /**
          * Builds a {@link KafkaConsumer} instance from the given {@link ExecutorService} and name,
          * for the given {@link Environment}.
-         * <p/>
+         * <p>
          * The name is used to identify the returned {@link KafkaConsumer} instance, for example, as
          * the name of its {@link com.codahale.metrics.health.HealthCheck}s, etc.
          *
@@ -597,7 +597,7 @@ public class KafkaConsumerFactory extends KafkaClientFactory {
         /**
          * Builds a {@link SynchronousConsumer} instance with this builders' configuration using the
          * given {@link ExecutorService}.
-         * <p/>
+         * <p>
          * If possible, it's always preferable to use one of the overloads that take an {@link
          * Environment} directly. This overload exists for situations where you don't have access to
          * an {@link Environment} (e.g. some Commands or unit tests).

--- a/dropwizard-extra-kafka7/src/main/java/com/datasift/dropwizard/kafka/consumer/MessageProcessor.java
+++ b/dropwizard-extra-kafka7/src/main/java/com/datasift/dropwizard/kafka/consumer/MessageProcessor.java
@@ -6,7 +6,7 @@ import kafka.message.MessageAndMetadata;
 
 /**
  * Processes messages of type {@code T} from a Kafka message stream.
- * <p/>
+ * <p>
  * This {@link StreamProcessor} is instrumented with {@link Metric}s; specifically, a {@link Timer}
  * that tracks the time taken to process each message in the stream.
  *

--- a/dropwizard-extra-kafka7/src/main/java/com/datasift/dropwizard/kafka/consumer/StreamProcessor.java
+++ b/dropwizard-extra-kafka7/src/main/java/com/datasift/dropwizard/kafka/consumer/StreamProcessor.java
@@ -4,10 +4,10 @@ import kafka.message.MessageAndMetadata;
 
 /**
  * Processes an {@link Iterable} of messages of type {@code T}.
- * <p/>
+ * <p>
  * If you wish to process each message individually and iteratively, it's advised that you instead
  * use a {@link MessageProcessor}, as it provides a higher-level of abstraction.
- * <p/>
+ * <p>
  * <i>Note: since consumers may use multiple threads, it is important that implementations are
  * thread-safe.</i>
  */

--- a/dropwizard-extra-kafka7/src/main/java/com/datasift/dropwizard/kafka/consumer/SynchronousConsumer.java
+++ b/dropwizard-extra-kafka7/src/main/java/com/datasift/dropwizard/kafka/consumer/SynchronousConsumer.java
@@ -116,11 +116,11 @@ public class SynchronousConsumer<T> implements KafkaConsumer, Managed, ServerLif
 
     /**
      * Starts this {@link SynchronousConsumer} immediately.
-     * <p/>
+     * <p>
      * The consumer will immediately begin consuming from the configured topics using the configured
      * {@link Decoder} to decode messages and {@link StreamProcessor} to process the decoded
      * messages.
-     * <p/>
+     * <p>
      * Each partition will be consumed using a separate thread.
      *
      * @throws Exception if an error occurs starting the consumer
@@ -197,10 +197,10 @@ public class SynchronousConsumer<T> implements KafkaConsumer, Managed, ServerLif
 
         /**
          * Process the stream using the configured {@link StreamProcessor}.
-         * <p/>
+         * <p>
          * If an {@link Exception} is thrown during processing, if it is deemed <i>recoverable</i>,
          * the stream will continue to be consumed.
-         * <p/>
+         * <p>
          * Unrecoverable {@link Exception}s will cause the consumer to shut down completely.
          */
         @Override

--- a/dropwizard-extra-kafka7/src/main/java/com/datasift/dropwizard/kafka/util/Compression.java
+++ b/dropwizard-extra-kafka7/src/main/java/com/datasift/dropwizard/kafka/util/Compression.java
@@ -9,10 +9,10 @@ import kafka.message.NoCompressionCodec;
 /**
  * A utility for parsing {@link CompressionCodec}s from a {@link
  * io.dropwizard.Configuration}.
- * <p/>
+ * <p>
  * To create {@link Compression} instances, use {@link Compression#parse(String)} to parse an
  * instance from a {@link String}.
- * <p/>
+ * <p>
  * This is provided to parse textual specifications of a {@link CompressionCodec}, for example in a
  * {@link io.dropwizard.Configuration}.
  */
@@ -22,9 +22,9 @@ public class Compression {
 
     /**
      * Creates a {@link Compression} instance for the given codec type.
-     * <p/>
+     * <p>
      * The valid codec values are defined by {@link CompressionCodec}.
-     * <p/>
+     * <p>
      * To create {@link Compression} instances, use the {@link Compression#parse(String)} factory
      * method to parse an instance from a {@link String}.
      *

--- a/dropwizard-extra-util/pom.xml
+++ b/dropwizard-extra-util/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.datasift.dropwizard</groupId>
     <artifactId>dropwizard-extra</artifactId>
-    <version>0.7.1-2-SNAPSHOT</version>
+    <version>0.9.1-1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/dropwizard-extra-util/src/main/java/com/datasift/dropwizard/health/SocketHealthCheck.java
+++ b/dropwizard-extra-util/src/main/java/com/datasift/dropwizard/health/SocketHealthCheck.java
@@ -7,7 +7,7 @@ import java.net.Socket;
 
 /**
  * A base {@link HealthCheck} for remote socket servers.
- * <p/>
+ * <p>
  * Use this as a basis for {@link HealthCheck}s for remote services, such as databases or
  * web-services.
  */
@@ -48,7 +48,7 @@ public abstract class SocketHealthCheck extends HealthCheck {
 
     /**
      * Generates a String representation of the remote socket being checked.
-     * <p/>
+     * <p>
      * This will be the socket address formatted as: hostname:port
      *
      * @return the String representation of the remote socket being checked.
@@ -91,7 +91,7 @@ public abstract class SocketHealthCheck extends HealthCheck {
 
     /**
      * Perform a check of a {@link Socket}.
-     * <p/>
+     * <p>
      * Implementations can assume that the {@link Socket} is already connected.
      *
      * @param socket the {@link Socket} to check the health of
@@ -99,8 +99,6 @@ public abstract class SocketHealthCheck extends HealthCheck {
      * @return if the component is healthy, a healthy {@link Result}; otherwise, an unhealthy {@link
      *         Result} with a description of the error or exception
      *
-     * @throws Exception if there is an unhandled error during the health check; this will result in
-     *                   a failed health check
      */
     protected abstract Result check(Socket socket);
 }

--- a/dropwizard-extra-util/src/main/java/com/datasift/dropwizard/util/Classes.java
+++ b/dropwizard-extra-util/src/main/java/com/datasift/dropwizard/util/Classes.java
@@ -12,7 +12,7 @@ public class Classes {
 
     /**
      * Creates a new instance of the given {@link Class}, using the given arguments.
-     * <p/>
+     * <p>
      * A new instance object of the given {@link Class} is created, using reflection,
      * providing the given arguments to the constructor.
      *
@@ -45,8 +45,8 @@ public class Classes {
     /**
      * Creates a new instance of the same {@link Class} as the given <i>template</i>, using the
      * given constructor arguments.
-     * <p/>
-     * Given an object of type <code>T</code>, a new instance of {@link Class<T>} will be created,
+     * <p>
+     * Given an object of type <code>T</code>, a new instance of {@link Class} will be created,
      * passing the given <i>args</i> to the constructor.
      *
      * @param template an object that provides the {@link Class} to instantiate.
@@ -80,10 +80,10 @@ public class Classes {
     /**
      * Creates a new instance of the given {@link Class}, using the given arguments, ignoring
      * visibility.
-     * <p/>
+     * <p>
      * A new instance object of the given {@link Class} is created, using reflection,
      * providing the given arguments to the constructor.
-     * <p/>
+     * <p>
      * The visibility of the {@link Constructor} defined by the arguments is ignored and a new
      * instance created irrespective of the defined visibility. This is potentially dangerous,
      * as the API likely makes no guarantee as to the behaviour when instantiating from a non-public
@@ -124,10 +124,10 @@ public class Classes {
     /**
      * Creates a new instance of the same {@link Class} as the given <i>template</i>, using the
      * given constructor arguments and ignoring visibility.
-     * <p/>
-     * Given an object of type <code>T</code>, a new instance of {@link Class<T>} will be created,
+     * <p>
+     * Given an object of type <code>T</code>, a new instance of {@link Class} will be created,
      * passing the given <i>args</i> to the constructor.
-     * <p/>
+     * <p>
      * The visibility of the {@link Constructor} defined by the arguments is ignored and a new
      * instance created irrespective of the defined visibility. This is potentially dangerous,
      * as the API likely makes no guarantee as to the behaviour when instantiating from a non-public
@@ -161,11 +161,11 @@ public class Classes {
 
     /**
      * Gets the {@link Class} for multiple objects.
-     * <p/>
+     * <p>
      * The resulting array of {@link Class} objects that are ordered in parallel with the argument
      * list that produced it. This is especially useful for getting a {@link Constructor} for a
      * given set of arguments:
-     * <p/>
+     * <p>
      * <code>
      *     clazz.getConstructor(Classes.of("abc", 123));
      * </code>
@@ -184,16 +184,16 @@ public class Classes {
 
     /**
      * Ensures a variable argument list has been properly passed.
-     * <p/>
+     * <p>
      * Sometimes, you want to pass a single array-typed argument to a method that accepts
      * variable arguments. In these situations, that array will be unwrapped in to a list of
      * multiple arguments, instead of a single argument that is an array.
-     * <p/>
+     * <p>
      * Example:
      * <code>
      *     Classes.of(TableNotFoundException.class, tableName.getBytes());
      * </code>
-     * <p/>
+     * <p>
      * Resolving will differentiate a variable argument list from a single argument of the
      * following types:
      * <ul>
@@ -217,14 +217,14 @@ public class Classes {
     /**
      * Gets a {@link Constructor} from the given {@link Class} that is applicable to the given
      * arguments.
-     * <p/>
+     * <p>
      * If the types of the given arguments are not an exact match for any declared {@link
      * Constructor}s, a Constructor that will accept the arguments (e.g. because they are
      * sub-types of the parameters) will be searched for.
-     * <p/>
+     * <p>
      * If the given {@link Class} has no {@link Constructor} that is applicable to the given
      * arguments, a {@link NoSuchMethodException} will be thrown.
-     * <p/>
+     * <p>
      * No guarantees are made about the visibility of the {@link Constructor} returned; it may not
      * be accessible from the calling scope.
      *
@@ -254,14 +254,14 @@ public class Classes {
     /**
      * Gets the {@link Method} of the given name from the given {@link Class} that is applicable
      * to the given argument types.
-     * <p/>
+     * <p>
      * If the types of the given arguments are not an exact match for any declared {@link Method}s,
      * a {@link Method} that will accept the arguments (e.g. because they are sub-types of the
      * parameters) will be searched for.
-     * <p/>
+     * <p>
      * If the given {@link Class} has no {@link Method} with the given name that is applicable to
      * the given arguments, a {@link NoSuchMethodException} will be thrown.
-     * <p/>
+     * <p>
      * No guarantees are made about the visibility of the {@link Method} returned; it may not be
      * accessible from the calling scope. Similarly, the {@link Method} may be static or may be an
      * instance method.
@@ -291,7 +291,7 @@ public class Classes {
     /**
      * Determines if the {@link Class}s for the given target types can be assigned to from the
      * types represented by the given source {@link Class}s.
-     * <p/>
+     * <p>
      * Each target type will be matched up with the corresponding source type. If the length of the
      * two arrays differ, they are considered not assignable.
      *
@@ -324,7 +324,7 @@ public class Classes {
     /***
      * Determines if the given source {@link Class} represents a type that can be assigned to the
      * given target {@link Class}.
-     * <p/>
+     * <p>
      * If the source {@link Class} represents null (via {@link Null}), it can be assigned to any
      * {@link Class} that represents a reference type.
      *
@@ -345,7 +345,7 @@ public class Classes {
 
     /**
      * A placeholder Null type.
-     * <p/>
+     * <p>
      * This Null type provides a means to get a {@link Class} for null values. This should never be
      * used except for special-casing nulls.
      */

--- a/dropwizard-extra-util/src/main/java/com/datasift/dropwizard/util/Exceptions.java
+++ b/dropwizard-extra-util/src/main/java/com/datasift/dropwizard/util/Exceptions.java
@@ -7,7 +7,7 @@ public class Exceptions {
 
     /**
      * Creates a new {@link Exception} instance from the given {@link Class}, using the given args.
-     * <p/>
+     * <p>
      * A new {@link Exception} instance object of the given {@link Class} is created, using
      * reflection, providing the given arguments to the constructor.
      *
@@ -28,7 +28,7 @@ public class Exceptions {
     /**
      * Creates a new {@link Exception} instance of the same {@link Class} as the given
      * <i>template</i>, using the given constructor args.
-     * <p/>
+     * <p>
      * A new {@link Exception} instance object of the given {@link Class} is created, using
      * reflection, providing the given arguments to the constructor.
      *
@@ -50,10 +50,10 @@ public class Exceptions {
     /**
      * Creates a new {@link Exception} instance from the given {@link Class}, using the given args,
      * ignoring visibility.
-     * <p/>
+     * <p>
      * A new {@link Exception} instance object of the given {@link Class} is created, using
      * reflection, providing the given arguments to the constructor.
-     * <p/>
+     * <p>
      * The visibility of the constructor defined by the arguments is ignored and a new instance
      * created irrespective of the defined visibility. This is potentially dangerous, as the API
      * likely makes no guarantee as to the behaviour when instantiating from a non-public
@@ -77,10 +77,10 @@ public class Exceptions {
     /**
      * Creates a new {@link Exception} instance of the same {@link Class} as the given
      * <i>template</i>, using the given constructor args, ignoring visibility.
-     * <p/>
+     * <p>
      * A new {@link Exception} instance object of the given {@link Class} is created, using
      * reflection, providing the given arguments to the constructor.
-     * <p/>
+     * <p>
      * The visibility of the constructor defined by the arguments is ignored and a new instance
      * created irrespective of the defined visibility. This is potentially dangerous, as the API
      * likely makes no guarantee as to the behaviour when instantiating from a non-public

--- a/dropwizard-extra-util/src/main/java/com/datasift/dropwizard/util/Primitives.java
+++ b/dropwizard-extra-util/src/main/java/com/datasift/dropwizard/util/Primitives.java
@@ -10,18 +10,18 @@ import java.util.Set;
 
 /**
  * Utilities for working with primitive types and reflection.
- * <p/>
+ * <p>
  * <b>Terminology:</b>
- * <p/>
+ * <p>
  * Non-reference primitive types (e.g. <code>int</code>, <code>double</code>, <code>void</code>)
  * are considered <i>native primitives</i>, or sometimes, <i>unboxed primitives</i>.
- * <p/>
+ * <p>
  * Reference primitive types (e.g. {@link Integer}, {@link Double}, {@link Void}) are considered
  * <i>boxed primitives</i>.
- * <p/>
+ * <p>
  * Conversion between native primitves and boxed primitives can be done with {@link
  * Primitives#box(Class)} and {@link Primitives#unbox(Class)}.
- * <p/>
+ * <p>
  * Whenever possible, boxing/unboxing will be implicit and transparent, with a preference for
  * native primitive types.
  */
@@ -89,7 +89,7 @@ public class Primitives {
     /**
      * Determines whether the objects of the given source {@link Class} can be assigned to the
      * primitive type of the given target {@link Class}.
-     * <p/>
+     * <p>
      * If either type is a boxed-primitive, it will be unboxed automatically; all comparisons
      * will be of the native primitive types.
      *
@@ -124,7 +124,7 @@ public class Primitives {
 
     /**
      * Determines whether the given {@link Class} is for a primitive type; either native or boxed.
-     * <p/>
+     * <p>
      * Both boxed and native primitive types are considered "primitives". Example:
      * <code>
      *     Primitives.isPrimitive(int.class) == true;
@@ -143,7 +143,7 @@ public class Primitives {
 
     /**
      * Determines whether the given {@link Class} is for a boxed primitive type.
-     * <p/>
+     * <p>
      * Only boxed primitive types are accepted. Example:
      * <code>
      *     Primitives.isPrimitive(int.class) == false;
@@ -162,7 +162,7 @@ public class Primitives {
 
     /**
      * Determines whether the given {@link Class} is for a native primitive type.
-     * <p/>
+     * <p>
      * Only native primitive types are accepted. Example:
      * <code>
      *     Primitives.isPrimitive(int.class) == true;

--- a/dropwizard-extra-zookeeper/pom.xml
+++ b/dropwizard-extra-zookeeper/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.datasift.dropwizard</groupId>
     <artifactId>dropwizard-extra</artifactId>
-    <version>0.7.1-2-SNAPSHOT</version>
+    <version>0.9.1-1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   

--- a/dropwizard-extra-zookeeper/src/main/java/com/datasift/dropwizard/zookeeper/ZooKeeperFactory.java
+++ b/dropwizard-extra-zookeeper/src/main/java/com/datasift/dropwizard/zookeeper/ZooKeeperFactory.java
@@ -218,7 +218,7 @@ public class ZooKeeperFactory {
 
     /**
      * Returns the namespace to prepend to all paths accessed by the ZooKeeper client.
-     * <p/>
+     * <p>
      * Since ZooKeeper is a shared space, this is a useful way to localise a service to a namespace.
      *
      * @return the namespace to prepend to all paths accessed by the ZooKeeper client.
@@ -230,7 +230,7 @@ public class ZooKeeperFactory {
 
     /**
      * Sets the namespace to prepend to all paths accessed by the ZooKeeper client.
-     * <p/>
+     * <p>
      * Since ZooKeeper is a shared space, this is a useful way to localise a service to a namespace.
      *
      * @param namespace the namespace to prepend to all paths accessed by the ZooKeeper client.
@@ -242,7 +242,7 @@ public class ZooKeeperFactory {
 
     /**
      * Returns whether or not this client can connect to read-only ZooKeeper instances.
-     * <p/>
+     * <p>
      * During a network partition, some or all nodes in the quorum may be in a read-only state. This
      * controls whether the client may enter read-only mode during a network partition.
      *
@@ -255,7 +255,7 @@ public class ZooKeeperFactory {
 
     /**
      * Sets whether or not this client can connect to read-only ZooKeeper instances.
-     * <p/>
+     * <p>
      * During a network partition, some or all nodes in the quorum may be in a read-only state. This
      * controls whether the client may enter read-only mode during a network partition.
      *
@@ -268,7 +268,7 @@ public class ZooKeeperFactory {
 
     /**
      * Retrieves a formatted specification of the ZooKeeper quorum..
-     * <p/>
+     * <p>
      * The specification is formatted as: host1:port,host2:port[,hostN:port]
      *
      * @return a specification of the ZooKeeper quorum, formatted as a String
@@ -285,7 +285,7 @@ public class ZooKeeperFactory {
 
     /**
      * Validates that the ZooKeeper client namespace is a valid ZNode.
-     * <p/>
+     * <p>
      * Note: this validation doesn't ensure that the ZNode exists, just that it is valid.
      *
      * @return true if the namespace is a valid ZNode; false if it is not.
@@ -302,7 +302,7 @@ public class ZooKeeperFactory {
 
     /**
      * Builds a default {@link ZooKeeper} instance..
-     * <p/>
+     * <p>
      * No {@link Watcher} will be configured for the built {@link ZooKeeper} instance. If you wish
      * to watch all events on the {@link ZooKeeper} client, use {@link #build(Environment, Watcher)}.
      *
@@ -319,7 +319,7 @@ public class ZooKeeperFactory {
 
     /**
      * Builds a default {@link ZooKeeper} instance.
-     * <p/>
+     * <p>
      * The given {@link Watcher} will be assigned to watch for all events on the {@link ZooKeeper}
      * client instance. If you wish to ignore events, use {@link #build(Environment)}.
      *
@@ -338,7 +338,7 @@ public class ZooKeeperFactory {
 
     /**
      * Builds a named {@link ZooKeeper} instance.
-     * <p/>
+     * <p>
      * No {@link Watcher} will be configured for the built {@link ZooKeeper} instance. If you wish
      * to watch all events on the {@link ZooKeeper} client, use {@link
      * #build(Environment, Watcher, String)}.
@@ -358,7 +358,7 @@ public class ZooKeeperFactory {
 
     /**
      * Builds a named {@link ZooKeeper} instance.
-     * <p/>
+     * <p>
      * The given {@link Watcher} will be assigned to watch for all events on the {@link ZooKeeper}
      * client instance. If you wish to ignore events, use {@link #build(Environment, String)}.
      *

--- a/dropwizard-extra-zookeeper/src/main/java/com/datasift/dropwizard/zookeeper/ZooKeeperFactory.java
+++ b/dropwizard-extra-zookeeper/src/main/java/com/datasift/dropwizard/zookeeper/ZooKeeperFactory.java
@@ -19,7 +19,7 @@ import java.io.IOException;
 
 /**
  * A Factory for creating configured and managed {@link ZooKeeper} client instances.
- * <p/>
+ * <p>
  * A {@link ZooKeeperHealthCheck} will be registered for each {@link ZooKeeper} client instance that
  * checks for the existence of the configured {@link #namespace}.
  *
@@ -63,7 +63,7 @@ public class ZooKeeperFactory {
 
         /**
          * Returns the authorization id to use.
-         * <p/>
+         * <p>
          * This is dependent on the authorization {@link #getScheme() scheme} being used.
          *
          * @return the scheme-specific authorization id.
@@ -77,7 +77,7 @@ public class ZooKeeperFactory {
 
         /**
          * Sets the authorization id to use.
-         * <p/>
+         * <p>
          * This is dependent on the authorization {@link #getScheme() scheme} being used.
          *
          * @param id the scheme-specific authorization id.

--- a/dropwizard-extra-zookeeper/src/main/java/com/datasift/dropwizard/zookeeper/health/ZooKeeperHealthCheck.java
+++ b/dropwizard-extra-zookeeper/src/main/java/com/datasift/dropwizard/zookeeper/health/ZooKeeperHealthCheck.java
@@ -5,7 +5,7 @@ import org.apache.zookeeper.ZooKeeper;
 
 /**
  * A {@link HealthCheck} for a ZooKeeper ensemble.
- * <p/>
+ * <p>
  * Checks that:
  * <ul>
  *     <li>the client is alive,</li>
@@ -24,7 +24,6 @@ public class ZooKeeperHealthCheck extends HealthCheck {
      *
      * @param client the client to check the health of.
      * @param namespace the namespace to check for within the ZooKeeper ensemble.
-     * @param name the name of this {@link HealthCheck}.
      */
     public ZooKeeperHealthCheck(final ZooKeeper client, final String namespace) {
         this.client = client;

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 
   <groupId>com.datasift.dropwizard</groupId>
   <artifactId>dropwizard-extra</artifactId>
-  <version>0.7.1-2-SNAPSHOT</version>
+  <version>0.9.1-1-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Dropwizard Extra</name>
@@ -28,7 +28,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.build.outputEncoding>UTF-8</project.build.outputEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <dropwizard.version>0.7.1</dropwizard.version>
+    <dropwizard.version>0.9.1</dropwizard.version>
   </properties>
 
   <organization>

--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@
     <module>dropwizard-extra-curator</module>
     <module>dropwizard-extra-hbase</module>
     <module>dropwizard-extra-kafka</module>
-    <module>dropwizard-extra-kafka7</module>
+    
     <module>dropwizard-extra-zookeeper</module>
     <module>dropwizard-extra-util</module>
   </modules>


### PR DESCRIPTION
I made a few simple modifications to the project, which include:
- Updating the JavaDoc so it would all process properly.  There were some non-compliant javadoc statements that would not process if you built the javadoc through Maven
- Upgraded dropwizard to 0.9.1.
- Upgraded the Kafka version from 0.8.1.1 to 0.8.2.2
- Removed the Kafka7 module from the overall POM and build (easy to add back, if needed)
- Upgraded asynchbase from 1.4.1 to 1.7.0 and made some changes in the health checks to reflect the hbase upgrade (.META and .ROOT don't exist any longer in newer versions of hbase)

Initially these changes were not going to be part of a pull request, but I had requests to see if we could get some of these into the main project ... as such I didn't break them into different branch / commit sets because performing these upgrades were viewed as a single "upgrade" operation.  
